### PR TITLE
ci: add support for multi-node template

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,6 +1,6 @@
 ---
 name: Main
-on: [push, pull_request]
+on: [push]
 env:
   DOCKER_BUILDKIT: 1
   KUBECONFIG: ./kubeconfig
@@ -65,83 +65,14 @@ jobs:
           sleep 30
           ./hack/test-smoke.sh
 
+  # This uses the reusable-multi-node.yaml template
   multi-node:
-    name: "Multi node (emulated using Lima)"
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - lima-template: template://ubuntu-24.04
-            engine: docker
-          - lima-template: template://ubuntu-24.04
-            engine: nerdctl
-          - lima-template: template://centos-stream-9
-            engine: podman
-          - lima-template: template://fedora
-            engine: podman
-    env:
-      LIMA_TEMPLATE: "${{ matrix.lima-template }}"
-      CONTAINER_ENGINE: "${{ matrix.engine }}"
-    steps:
-      - uses: actions/checkout@v4
-      - name: "Install QEMU"
-        run: |
-          set -eux
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ovmf qemu-system-x86 qemu-utils
-          sudo modprobe kvm
-          # `sudo usermod -aG kvm $(whoami)` does not take an effect on GHA
-          sudo chown $(whoami) /dev/kvm
+    name: "Multi node with defaults"
+    uses: ./.github/workflows/reusable-multi-node.yaml
 
-      - name: "Install Lima"
-        env:
-          GITHUB_TOKEN: ${{ github.token }}  # required by `gh attestation verify`
-        run: |
-          set -eux
-          LIMA_VERSION=$(curl -fsSL https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
-          FILE="lima-${LIMA_VERSION:1}-Linux-x86_64.tar.gz"
-          curl -fOSL https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/${FILE}
-          gh attestation verify --owner=lima-vm "${FILE}"
-          sudo tar Cxzvf /usr/local "${FILE}"
-          rm -f "${FILE}"
-
-      - name: "Cache ~/.cache/lima"
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/lima
-          key: lima-${{ env.LIMA_VERSION }}
-
-      - name: "Relax disk pressure limit"
-        run: |
-          set -x
-          sudo snap install yq
-          yq -i 'select(.kind=="KubeletConfiguration").evictionHard."imagefs.available"="3Gi"' kubeadm-config.yaml
-      - run: ./hack/create-cluster-lima.sh
-      - run: kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
-      - run: ./hack/test-smoke.sh
-      - if: failure()
-        name: "kubectl get nodes"
-        run: |
-          set -x
-          kubectl get nodes -o wide
-          kubectl get nodes -o yaml
-          limactl shell host0 df -h
-          limactl shell host1 df -h
-      - if: failure()
-        name: "kubectl get pods"
-        run: |
-          set -x
-          kubectl get pods -A -o yaml
-          limactl shell host0 journalctl --user --no-pager --since "10 min ago"
-      - name: "Test data persistency after restarting the node"
-        run: |
-          limactl stop host0
-          limactl stop host1
-          limactl start host0
-          limactl start host1
-          # The plain mode of Lima disables automatic port forwarding
-          ssh -q -f -N -L 6443:127.0.0.1:6443 -F ~/.lima/host0/ssh.config lima-host0
-          sleep 30
-          ./hack/test-smoke.sh
+  multi-node-custom-port:
+    name: "Multi node with custom kube-apiserver port"
+    uses: ./.github/workflows/reusable-multi-node.yaml
+    with:
+      # Defaults to 6443
+      kube_apiserver_port: "8080"

--- a/.github/workflows/reusable-multi-node.yaml
+++ b/.github/workflows/reusable-multi-node.yaml
@@ -1,0 +1,99 @@
+name: Multi Node
+on:  
+  workflow_call:
+    # allow reuse of this workflow in other files here
+    inputs:
+      kube_apiserver_port:
+        description: Kubernetes API server port
+        # Using string, might be bug with number
+        # https://github.com/orgs/community/discussions/67182
+        type: string
+        default: "6443"
+
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idpermissions
+permissions: read-all
+
+jobs:
+  multi-node:
+    name: "Multi node (emulated using Lima)"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - lima-template: template://ubuntu-24.04
+            engine: docker
+          - lima-template: template://ubuntu-24.04
+            engine: nerdctl
+          - lima-template: template://centos-stream-9
+            engine: podman
+          - lima-template: template://fedora
+            engine: podman
+    env:
+      LIMA_TEMPLATE: "${{ matrix.lima-template }}"
+      CONTAINER_ENGINE: "${{ matrix.engine }}"
+      U7S_EXPOSED_PORT_KUBE_APISERVER: "${{ inputs.kube_apiserver_port }}"
+      DOCKER_BUILDKIT: 1
+      KUBECONFIG: ./kubeconfig
+    steps:
+      - uses: actions/checkout@v4
+      - name: "Install QEMU"
+        run: |
+          set -eux
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ovmf qemu-system-x86 qemu-utils
+          sudo modprobe kvm
+          # `sudo usermod -aG kvm $(whoami)` does not take an effect on GHA
+          sudo chown $(whoami) /dev/kvm
+
+      - name: "Install Lima"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}  # required by `gh attestation verify`
+        run: |
+          set -eux
+          LIMA_VERSION=$(curl -fsSL https://api.github.com/repos/lima-vm/lima/releases/latest | jq -r .tag_name)
+          FILE="lima-${LIMA_VERSION:1}-Linux-x86_64.tar.gz"
+          curl -fOSL https://github.com/lima-vm/lima/releases/download/${LIMA_VERSION}/${FILE}
+          gh attestation verify --owner=lima-vm "${FILE}"
+          sudo tar Cxzvf /usr/local "${FILE}"
+          rm -f "${FILE}"
+
+      - name: "Cache ~/.cache/lima"
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/lima
+          key: lima-${{ env.LIMA_VERSION }}
+
+      - name: "Relax disk pressure limit"
+        run: |
+          set -x
+          sudo snap install yq
+          yq -i 'select(.kind=="KubeletConfiguration").evictionHard."imagefs.available"="3Gi"' kubeadm-config.yaml
+      - run: ./hack/create-cluster-lima.sh
+      - run: kubectl taint nodes --all node-role.kubernetes.io/control-plane- || true
+      - run: ./hack/test-smoke.sh
+      - if: failure()
+        name: "kubectl get nodes"
+        run: |
+          set -x
+          kubectl get nodes -o wide
+          kubectl get nodes -o yaml
+          limactl shell host0 df -h
+          limactl shell host1 df -h
+      - if: failure()
+        name: "kubectl get pods"
+        run: |
+          set -x
+          kubectl get pods -A -o yaml
+          limactl shell host0 journalctl --user --no-pager --since "10 min ago"
+      - name: "Test data persistency after restarting the node"
+        run: |
+          limactl stop host0
+          limactl stop host1
+          limactl start host0
+          limactl start host1
+          # The plain mode of Lima disables automatic port forwarding
+          ssh -q -f -N -L ${{ inputs.kube_apiserver_port }}:127.0.0.1:${{ inputs.kube_apiserver_port }} -F ~/.lima/host0/ssh.config lima-host0
+          sleep 30
+          ./hack/test-smoke.sh

--- a/.github/workflows/reusable-multi-node.yaml
+++ b/.github/workflows/reusable-multi-node.yaml
@@ -33,7 +33,7 @@ jobs:
     env:
       LIMA_TEMPLATE: "${{ matrix.lima-template }}"
       CONTAINER_ENGINE: "${{ matrix.engine }}"
-      U7S_EXPOSED_PORT_KUBE_APISERVER: "${{ inputs.kube_apiserver_port }}"
+      U7S_PORT_KUBE_APISERVER: "${{ inputs.kube_apiserver_port }}"
       DOCKER_BUILDKIT: 1
       KUBECONFIG: ./kubeconfig
     steps:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,14 +11,15 @@ services:
       default:
         ipv4_address: ${U7S_NODE_IP}
     ports:
-      # etcd
-      - ${U7S_EXPOSED_PORT_ETCD}:2379
-      # kube-apiserver
-      - ${U7S_EXPOSED_PORT_KUBE_APISERVER}:6443
-      # kubelet
-      - ${U7S_EXPOSED_PORT_KUBELET}:10250
-      # flannel
-      - ${U7S_EXPOSED_PORT_FLANNEL}:8472/udp
+      # <host>:<container>
+      # etcd (default: 2379)
+      - ${U7S_PORT_ETCD}:${U7S_PORT_ETCD}
+      # kube-apiserver (default: 6443)
+      - ${U7S_PORT_KUBE_APISERVER}:${U7S_PORT_KUBE_APISERVER}
+      # kubelet (default: 10250)
+      - ${U7S_PORT_KUBELET}:${U7S_PORT_KUBELET}
+      # flannel (default: 8472)
+      - ${U7S_PORT_FLANNEL}:${U7S_PORT_FLANNEL}/udp
     volumes:
       - .:/usernetes:ro
       - /boot:/boot:ro

--- a/hack/create-cluster-lima.sh
+++ b/hack/create-cluster-lima.sh
@@ -5,7 +5,7 @@ set -eux -o pipefail
 : "${LIMA_TEMPLATE:=template://default}"
 : "${CONTAINER_ENGINE:=docker}"
 : "${LOCKDOWN_SUDO:=1}"
-: "${U7S_EXPOSED_PORT_KUBE_APISERVER:=6443}"
+: "${U7S_PORT_KUBE_APISERVER:=6443}"
 
 guest_home="/home/${USER}.linux"
 
@@ -22,28 +22,27 @@ for host in host0 host1; do
 		# Lockdown sudo to ensure rootless-ness
 		${LIMACTL} shell "${host}" sudo sh -euxc 'rm -rf /etc/sudoers.d/*-cloud-init-users'
 	fi
-	${LIMACTL} shell "${host}" U7S_EXPOSED_PORT_KUBE_APISERVER=${U7S_EXPOSED_PORT_KUBE_APISERVER} \
-	                           CONTAINER_ENGINE="${CONTAINER_ENGINE}" "${guest_home}/usernetes/init-host/init-host.rootless.sh"
+	${LIMACTL} shell "${host}" CONTAINER_ENGINE="${CONTAINER_ENGINE}" "${guest_home}/usernetes/init-host/init-host.rootless.sh"
 done
 
 # Launch a Kubernetes node inside a Rootless Docker host
 for host in host0 host1; do
-	${LIMACTL} shell "${host}" CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C "${guest_home}/usernetes" up
+	${LIMACTL} shell "${host}" U7S_PORT_KUBE_APISERVER=${U7S_PORT_KUBE_APISERVER} CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C "${guest_home}/usernetes" up
 done
 
 # Bootstrap a cluster with host0
-${LIMACTL} shell host0 U7S_EXPOSED_PORT_KUBE_APISERVER=${U7S_EXPOSED_PORT_KUBE_APISERVER} \
+${LIMACTL} shell host0 U7S_PORT_KUBE_APISERVER=${U7S_PORT_KUBE_APISERVER} \
                        CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C "${guest_home}/usernetes" kubeadm-init install-flannel kubeconfig join-command
 
 # Let host1 join the cluster
 ${LIMACTL} copy host0:~/usernetes/join-command host1:~/usernetes/join-command
-${LIMACTL} shell host1 U7S_EXPOSED_PORT_KUBE_APISERVER=${U7S_EXPOSED_PORT_KUBE_APISERVER} \
+${LIMACTL} shell host1 U7S_PORT_KUBE_APISERVER=${U7S_PORT_KUBE_APISERVER} \
                        CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C "${guest_home}/usernetes" kubeadm-join
-${LIMACTL} shell host0 U7S_EXPOSED_PORT_KUBE_APISERVER=${U7S_EXPOSED_PORT_KUBE_APISERVER} \
+${LIMACTL} shell host0 U7S_PORT_KUBE_APISERVER=${U7S_PORT_KUBE_APISERVER} \
                        CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C "${guest_home}/usernetes" sync-external-ip
 
 # Enable kubectl
-ssh -q -f -N -L ${U7S_EXPOSED_PORT_KUBE_APISERVER}:127.0.0.1:${U7S_EXPOSED_PORT_KUBE_APISERVER} -F ~/.lima/host0/ssh.config lima-host0
+ssh -q -f -N -L ${U7S_PORT_KUBE_APISERVER}:127.0.0.1:${U7S_PORT_KUBE_APISERVER} -F ~/.lima/host0/ssh.config lima-host0
 ${LIMACTL} copy host0:${guest_home}/usernetes/kubeconfig ./kubeconfig
 KUBECONFIG="$(pwd)/kubeconfig"
 export KUBECONFIG

--- a/hack/create-cluster-lima.sh
+++ b/hack/create-cluster-lima.sh
@@ -5,6 +5,7 @@ set -eux -o pipefail
 : "${LIMA_TEMPLATE:=template://default}"
 : "${CONTAINER_ENGINE:=docker}"
 : "${LOCKDOWN_SUDO:=1}"
+: "${U7S_EXPOSED_PORT_KUBE_APISERVER:=6443}"
 
 guest_home="/home/${USER}.linux"
 
@@ -21,7 +22,8 @@ for host in host0 host1; do
 		# Lockdown sudo to ensure rootless-ness
 		${LIMACTL} shell "${host}" sudo sh -euxc 'rm -rf /etc/sudoers.d/*-cloud-init-users'
 	fi
-	${LIMACTL} shell "${host}" CONTAINER_ENGINE="${CONTAINER_ENGINE}" "${guest_home}/usernetes/init-host/init-host.rootless.sh"
+	${LIMACTL} shell "${host}" U7S_EXPOSED_PORT_KUBE_APISERVER=${U7S_EXPOSED_PORT_KUBE_APISERVER} \
+	                           CONTAINER_ENGINE="${CONTAINER_ENGINE}" "${guest_home}/usernetes/init-host/init-host.rootless.sh"
 done
 
 # Launch a Kubernetes node inside a Rootless Docker host
@@ -30,15 +32,18 @@ for host in host0 host1; do
 done
 
 # Bootstrap a cluster with host0
-${LIMACTL} shell host0 CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C "${guest_home}/usernetes" kubeadm-init install-flannel kubeconfig join-command
+${LIMACTL} shell host0 U7S_EXPOSED_PORT_KUBE_APISERVER=${U7S_EXPOSED_PORT_KUBE_APISERVER} \
+                       CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C "${guest_home}/usernetes" kubeadm-init install-flannel kubeconfig join-command
 
 # Let host1 join the cluster
 ${LIMACTL} copy host0:~/usernetes/join-command host1:~/usernetes/join-command
-${LIMACTL} shell host1 CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C "${guest_home}/usernetes" kubeadm-join
-${LIMACTL} shell host0 CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C "${guest_home}/usernetes" sync-external-ip
+${LIMACTL} shell host1 U7S_EXPOSED_PORT_KUBE_APISERVER=${U7S_EXPOSED_PORT_KUBE_APISERVER} \
+                       CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C "${guest_home}/usernetes" kubeadm-join
+${LIMACTL} shell host0 U7S_EXPOSED_PORT_KUBE_APISERVER=${U7S_EXPOSED_PORT_KUBE_APISERVER} \
+                       CONTAINER_ENGINE="${CONTAINER_ENGINE}" make -C "${guest_home}/usernetes" sync-external-ip
 
 # Enable kubectl
-ssh -q -f -N -L 6443:127.0.0.1:6443 -F ~/.lima/host0/ssh.config lima-host0
+ssh -q -f -N -L ${U7S_EXPOSED_PORT_KUBE_APISERVER}:127.0.0.1:${U7S_EXPOSED_PORT_KUBE_APISERVER} -F ~/.lima/host0/ssh.config lima-host0
 ${LIMACTL} copy host0:${guest_home}/usernetes/kubeconfig ./kubeconfig
 KUBECONFIG="$(pwd)/kubeconfig"
 export KUBECONFIG

--- a/kubeadm-config.yaml
+++ b/kubeadm-config.yaml
@@ -1,27 +1,33 @@
----
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
+localAPIEndpoint:
+  bindPort: ${U7S_PORT_KUBE_APISERVER}
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
+controlPlaneEndpoint: "${U7S_NODE_NAME}:${U7S_PORT_KUBE_APISERVER}"
+apiServer:
+  certSANs:
+  - localhost
+  - 127.0.0.1
+  - "${U7S_NODE_NAME}"
+  - "${U7S_HOST_IP}"
+  extraArgs:
+  - name: advertise-address
+    value: ${U7S_HOST_IP}
+  - name: secure-port
+    value: "${U7S_PORT_KUBE_APISERVER}"
+  - name: cloud-provider
+    value: external
+  - name: kubelet-preferred-address-types
+    value: ExternalIP
+controllerManager:
+  extraArgs:
+    - name: cloud-provider
+      value: external
 networking:
   serviceSubnet: "10.96.0.0/16"
   podSubnet: "10.244.0.0/16"
-controlPlaneEndpoint: "${U7S_NODE_NAME}:${U7S_EXPOSED_PORT_KUBE_APISERVER}"
-apiServer:
-  extraArgs:
-    advertise-address: "${U7S_HOST_IP}"
-    cloud-provider: external
-    # Default: "Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP"
-    kubelet-preferred-address-types: "ExternalIP"
-  certSANs:
-    - localhost
-    - 127.0.0.1
-    - "${U7S_NODE_NAME}"
-    - "${U7S_HOST_IP}"
-controllerManager:
-  extraArgs:
-    cloud-provider: external
 ---
 kind: KubeletConfiguration
 apiVersion: kubelet.config.k8s.io/v1beta1


### PR DESCRIPTION
If we want to run the same logic more than once, we should use GitHub reusable workflows. This adds the logic for the multi-node tests, and we will first test changing the api server port.